### PR TITLE
feat: add export subcommand

### DIFF
--- a/src/cli/api/export.rs
+++ b/src/cli/api/export.rs
@@ -1,0 +1,39 @@
+use crate::{
+    cli::Cli,
+    file::{JsonFile, JsonLabel},
+    Result,
+};
+use clap::{AppSettings, Clap};
+use hubcaps::repositories::Repository;
+use std::fs;
+use tokio::stream::StreamExt;
+
+/// Export a repository's labels into a file.
+#[derive(Clap, Clone, Debug)]
+#[clap(author, setting(AppSettings::ColoredHelp), version)]
+pub struct ExportArgs {
+    /// The file to write the labels to.
+    #[clap(long, short)]
+    pub file: String,
+}
+
+impl ExportArgs {
+    pub async fn run(self, _cli: Cli, repo: Repository) -> Result<()> {
+        let labels = repo.labels().iter().collect::<Vec<_>>().await;
+        let (labels, _errored_labels): (Vec<_>, Vec<_>) =
+            labels.into_iter().partition(|r| r.is_ok());
+
+        let json_labels: Vec<JsonLabel> = labels
+            .into_iter()
+            .map(|v| v.unwrap())
+            .map(Into::into)
+            .collect();
+
+        let json_file = JsonFile {
+            labels: json_labels,
+        };
+
+        fs::write(self.file, serde_json::to_string(&json_file)?)?;
+        Ok(())
+    }
+}

--- a/src/cli/api/mod.rs
+++ b/src/cli/api/mod.rs
@@ -9,6 +9,7 @@ use git2::Repository;
 use std::env::current_dir;
 
 mod create;
+mod export;
 mod update;
 
 /// Interact with the GitHub API.
@@ -35,6 +36,7 @@ pub struct ApiArgs {
 #[derive(Clap, Clone, Debug)]
 pub enum ApiSubCommand {
     Create(create::CreateArgs),
+    Export(export::ExportArgs),
     Update(update::UpdateArgs),
 }
 
@@ -68,6 +70,7 @@ impl ApiArgs {
 
         match self.cmd {
             ApiSubCommand::Create(args) => args.run(cli, repo).await?,
+            ApiSubCommand::Export(args) => args.run(cli, repo).await?,
             ApiSubCommand::Update(args) => args.run(cli, repo).await?,
         }
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,12 +1,12 @@
 use eyre::{eyre, Context, Result};
-use hubcaps::labels::LabelOptions;
+use hubcaps::labels::{Label, LabelOptions};
 use serde::{Deserialize, Serialize};
 use std::{fs::File, path::Path};
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct JsonLabel {
     pub color: String,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub description: String,
     pub name: String,
 }
@@ -24,6 +24,16 @@ impl JsonLabel {
 impl From<JsonLabel> for LabelOptions {
     fn from(lbl: JsonLabel) -> Self {
         LabelOptions::new(lbl.name, lbl.color, lbl.description)
+    }
+}
+
+impl From<Label> for JsonLabel {
+    fn from(lbl: Label) -> Self {
+        Self {
+            color: lbl.color,
+            name: lbl.name,
+            description: lbl.description.unwrap_or_default(),
+        }
     }
 }
 


### PR DESCRIPTION
The export subcommand can be used to store a repository's labels into a
label definition file.

Closes #12