### PR TITLE
feat: add concurrent connections argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "directories-next",
  "edit",
  "eyre",
+ "futures",
  "git2",
  "hubcaps",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ color-eyre = "0.5.10"
 directories-next = "2.0.0"
 edit = "0.1.3"
 eyre = "0.6.5"
+futures = "0.3.13"
 git2 = { version = "0.13.17", features = ["vendored-openssl"] }
 hubcaps = "0.6.2"
 serde = "1.0.124"

--- a/src/cli/api/mod.rs
+++ b/src/cli/api/mod.rs
@@ -15,6 +15,13 @@ mod update;
 #[derive(Clap, Clone, Debug)]
 #[clap(author, setting(AppSettings::ColoredHelp), version)]
 pub struct ApiArgs {
+    #[clap(subcommand)]
+    pub cmd: ApiSubCommand,
+
+    /// The number of concurrent connections to make to the GitHub API.
+    #[clap(long)]
+    pub concurrent_connections: usize,
+
     /// The git repository to apply the changes to.
     ///
     /// Can be either a git url or a string in the format `owner/repo`. If not
@@ -27,9 +34,6 @@ pub struct ApiArgs {
     /// variables.
     #[clap(long, short)]
     pub token: Option<String>,
-
-    #[clap(subcommand)]
-    pub cmd: ApiSubCommand,
 }
 
 #[derive(Clap, Clone, Debug)]
@@ -68,7 +72,7 @@ impl ApiArgs {
 
         match self.cmd {
             ApiSubCommand::Create(args) => args.run(cli, repo).await?,
-            ApiSubCommand::Update(args) => args.run(cli, repo).await?,
+            ApiSubCommand::Update(args) => args.run(cli, repo, self.concurrent_connections).await?,
         }
 
         Ok(())

--- a/src/cli/api/update.rs
+++ b/src/cli/api/update.rs
@@ -1,10 +1,9 @@
 use crate::{cli::Cli, file::read_from_cli_arg_or_fallback_to_config_dir, Result};
 use clap::{AppSettings, Clap};
-use eyre::WrapErr;
+use futures::stream::{self, StreamExt};
 use hubcaps::repositories::Repository;
 use std::path::PathBuf;
-use terminal_log_symbols::colored::INFO_SYMBOL;
-use tokio::stream::StreamExt;
+use terminal_log_symbols::colored::{ERROR_SYMBOL, INFO_SYMBOL};
 
 /// Updates all labels from a label definition file.
 #[derive(Clap, Clone, Debug)]
@@ -20,7 +19,12 @@ pub struct UpdateArgs {
 }
 
 impl UpdateArgs {
-    pub async fn run(self, _cli: Cli, repo: Repository) -> Result<()> {
+    pub async fn run(
+        self,
+        _cli: Cli,
+        repo: Repository,
+        concurrent_connections: usize,
+    ) -> Result<()> {
         let label_definition_file = read_from_cli_arg_or_fallback_to_config_dir(self.file)?;
         let labels = label_definition_file.labels;
 
@@ -69,20 +73,35 @@ impl UpdateArgs {
         );
 
         // Only create labels that are different from the ones that are already present.
-        for label in labels_to_create {
-            let label_name = label.name.clone();
-            repo.labels()
-                .create(&label.into())
-                .await
-                .wrap_err_with(|| format!("Failed to create label: {:?}", &label_name))?;
+        let fetches = stream::iter(labels_to_create.into_iter().map(|label| async {
+            (
+                label.name.clone(),
+                repo.labels().create(&label.into()).await,
+            )
+        }))
+        .buffer_unordered(concurrent_connections)
+        .collect::<Vec<_>>();
+        for (label_name, res) in fetches.await {
+            if let Err(_) = res {
+                eprintln!("{} Failed to create label {:?}", ERROR_SYMBOL, label_name);
+            }
         }
 
-        for label in labels_to_update {
-            let label_name = label.name.clone();
-            repo.labels()
-                .update(&label_name, &label.into())
-                .await
-                .wrap_err_with(|| format!("Failed to create label: {:?}", &label_name))?;
+        // TODO: can this be rewritten to not clone the name twice for error reporting?
+        let fetches = stream::iter(labels_to_update.into_iter().map(|label| async {
+            (
+                label.name.clone(),
+                repo.labels()
+                    .update(&label.name.clone(), &label.into())
+                    .await,
+            )
+        }))
+        .buffer_unordered(concurrent_connections)
+        .collect::<Vec<_>>();
+        for (label_name, res) in fetches.await {
+            if let Err(_) = res {
+                eprintln!("{} Failed to create label {:?}", ERROR_SYMBOL, label_name);
+            }
         }
 
         Ok(())

--- a/src/cli/api/update.rs
+++ b/src/cli/api/update.rs
@@ -82,7 +82,7 @@ impl UpdateArgs {
         .buffer_unordered(concurrent_connections)
         .collect::<Vec<_>>();
         for (label_name, res) in fetches.await {
-            if let Err(_) = res {
+            if res.is_err() {
                 eprintln!("{} Failed to create label {:?}", ERROR_SYMBOL, label_name);
             }
         }
@@ -99,7 +99,7 @@ impl UpdateArgs {
         .buffer_unordered(concurrent_connections)
         .collect::<Vec<_>>();
         for (label_name, res) in fetches.await {
-            if let Err(_) = res {
+            if res.is_err() {
                 eprintln!("{} Failed to create label {:?}", ERROR_SYMBOL, label_name);
             }
         }


### PR DESCRIPTION
The option can be used to limit the number of concurrent connections
that are made to the GitHub API.

Closes #1
Closes #8