### PR TITLE
fix: template section being mandatory on read

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -70,6 +70,6 @@ pub type JsonTemplates = Vec<JsonTemplate>;
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct JsonFile {
     pub labels: JsonLabels,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub templates: JsonTemplates,
 }


### PR DESCRIPTION
Templates are meant to be fully optional. This commit fixes deserialization by making the field optional inside the configuration file.

Fixes #31